### PR TITLE
More details in comment

### DIFF
--- a/Lyzer-BE/API/Controllers/HydrationController.cs
+++ b/Lyzer-BE/API/Controllers/HydrationController.cs
@@ -16,10 +16,16 @@ namespace Lyzer_BE.API.Controllers
         }
 
         // GET api/hydration/schedule
-        [HttpGet("schedule")]
+        [HttpGet("schedule/current")]
         public Task<ScheduleDTO> HydrateCurrentSchedule()
         {
             return _hydrationService.HydrateCurrentSchedule();
+        }
+
+        [HttpGet("schedule/next")]
+        public Task<ScheduleDTO> HydrateFollowingYearSchedule()
+        {
+            return _hydrationService.HydrateFollowingYearSchedule();
         }
     }
 }

--- a/Lyzer-BE/API/Controllers/ScheduleController.cs
+++ b/Lyzer-BE/API/Controllers/ScheduleController.cs
@@ -22,7 +22,7 @@ namespace Lyzer_BE.API.Controllers
             return _scheduleService.GetFullSchedule();
         }
 
-        [HttpGet("race/next")]
+        [HttpGet("/current/race/next")]
         public Task<RaceWeekendDTO>? GetNextEvent()
         {
             return _scheduleService.GetNextOrCurrentEvent();

--- a/Lyzer-BE/API/Controllers/ScheduleController.cs
+++ b/Lyzer-BE/API/Controllers/ScheduleController.cs
@@ -22,7 +22,7 @@ namespace Lyzer_BE.API.Controllers
             return _scheduleService.GetFullSchedule();
         }
 
-        [HttpGet("next")]
+        [HttpGet("race/next")]
         public Task<RaceWeekendDTO>? GetNextEvent()
         {
             return _scheduleService.GetNextOrCurrentEvent();

--- a/Lyzer-BE/API/Services/Concrete/HydrationService.cs
+++ b/Lyzer-BE/API/Services/Concrete/HydrationService.cs
@@ -15,11 +15,30 @@ namespace Lyzer_BE.API.Services.Concrete
             var request = new RestRequest($"current.json");
             var response = await client.GetAsync<ScheduleDTO>(request);
 
-            MongoController<RaceWeekendDTO> mongoController = new("Current Schedules");
+            MongoController<RaceWeekendDTO> mongoController = new("Schedules", "2023");
             var filterValues = Builders<RaceWeekendDTO>.Filter.Empty;
             mongoController.DeleteManyFromCollection(filterValues);
 
             mongoController.InsertManyIntoCollection(response.ScheduleData.ScheduleTable.RaceWeekends);
+            return response;
+        }
+
+        public async Task<ScheduleDTO> HydrateFollowingYearSchedule()
+        {
+            var options = new RestClientOptions("http://ergast.com/api/f1/");
+            var client = new RestClient(options);
+            var request = new RestRequest($"2024.json");
+            var response = await client.GetAsync<ScheduleDTO>(request);
+
+            MongoController<RaceWeekendDTO> mongoController = new("Schedules", "2024");
+            var filterValues = Builders<RaceWeekendDTO>.Filter.Empty;
+            mongoController.DeleteManyFromCollection(filterValues);
+
+            if (response.ScheduleData.ScheduleTable.RaceWeekends.Count != 0)
+            {
+                mongoController.InsertManyIntoCollection(response.ScheduleData.ScheduleTable.RaceWeekends);
+            }
+
             return response;
         }
     }

--- a/Lyzer-BE/API/Services/Concrete/ScheduleService.cs
+++ b/Lyzer-BE/API/Services/Concrete/ScheduleService.cs
@@ -7,40 +7,68 @@ namespace Lyzer_BE.API.Services.Concrete
 {
     public class ScheduleService : IScheduleService
     {
-        private readonly MongoController<RaceWeekendDTO> _mongoControllerCurrent;
-        private readonly MongoController<RaceWeekendDTO> _mongoControllerAll;
+        private readonly MongoController<RaceWeekendDTO> _mongoController;
+
         public ScheduleService(bool testing = false)
         {
             if (!testing)
             {
-                _mongoControllerCurrent = new MongoController<RaceWeekendDTO>("Current Schedules");
-                _mongoControllerAll = new MongoController<RaceWeekendDTO>("All Schedules");
+                var today = DateTime.Now;
+                var currentYear = today.Year;
+                _mongoController = new MongoController<RaceWeekendDTO>("Schedules", currentYear.ToString());
             }
         }
 
         public async Task<List<RaceWeekendDTO>>? GetFullSchedule()
         {
-            return await _mongoControllerCurrent.FindManyFromCollection(Builders<RaceWeekendDTO>.Filter.Empty);
+            return await _mongoController.FindManyFromCollection(Builders<RaceWeekendDTO>.Filter.Empty);
         }
 
         public async Task<RaceWeekendDTO>? GetNextOrCurrentEvent()
         {
-            var events = await _mongoControllerCurrent.FindManyFromCollection(Builders<RaceWeekendDTO>.Filter.Empty);
-
-            RaceWeekendDTO nextEvent = new RaceWeekendDTO();
             var today = DateTime.Now;
+            var twoYearsFromNow = today.AddYears(2);
+
+            RaceWeekendDTO nextEvent = new()
+            {
+                Date = $"{twoYearsFromNow.Year}-01-01",
+                Time = "00:00:00",
+            };
+
+            _mongoController.SetCollection(today.Year.ToString());
+            var events = await _mongoController.FindManyFromCollection(Builders<RaceWeekendDTO>.Filter.Empty);
+
+
             foreach (RaceWeekendDTO eventDTO in events)
             {
+                var nextEventDatetime = DateTime.Parse($"{nextEvent.Date} {nextEvent.Time}").AddHours(2.5);
                 var endDateTime = DateTime.Parse($"{eventDTO.Date} {eventDTO.Time}").AddHours(2.5);
-                if (endDateTime > today)
+
+                if (endDateTime > today && nextEventDatetime > endDateTime)
                 {
                     nextEvent = eventDTO;
-                    break;
                 }
+            };
+
+            if (nextEvent.Date == $"{twoYearsFromNow.Year}-01-01")
+            {
+                _mongoController.SetCollection((today.Year + 1).ToString());
+                var nextYearEvents = await _mongoController.FindManyFromCollection(Builders<RaceWeekendDTO>.Filter.Empty);
+
+                foreach (RaceWeekendDTO eventDTO in nextYearEvents)
+                {
+                    var nextEventDatetime = DateTime.Parse($"{nextEvent.Date} {nextEvent.Time}").AddHours(2.5);
+                    var endDateTime = DateTime.Parse($"{eventDTO.Date} {eventDTO.Time}").AddHours(2.5);
+
+                    if (endDateTime > today && nextEventDatetime > endDateTime)
+                    {
+                        nextEvent = eventDTO;
+                    }
+                };
             }
-            //Edge case: someway to account for the last race, what do we return then?
 
             return nextEvent;
         }
     }
 }
+

--- a/Lyzer-BE/API/Services/Concrete/ScheduleService.cs
+++ b/Lyzer-BE/API/Services/Concrete/ScheduleService.cs
@@ -35,9 +35,7 @@ namespace Lyzer_BE.API.Services.Concrete
                 Time = "00:00:00",
             };
 
-            _mongoController.SetCollection(today.Year.ToString());
             var events = await _mongoController.FindManyFromCollection(Builders<RaceWeekendDTO>.Filter.Empty);
-
 
             foreach (RaceWeekendDTO eventDTO in events)
             {

--- a/Lyzer-BE/API/Services/Interfaces/IHydrationService.cs
+++ b/Lyzer-BE/API/Services/Interfaces/IHydrationService.cs
@@ -5,5 +5,7 @@ namespace Lyzer_BE.API.Services.Interfaces
     public interface IHydrationService
     {
         public Task<ScheduleDTO> HydrateCurrentSchedule();
+
+        public Task<ScheduleDTO> HydrateFollowingYearSchedule();
     }
 }

--- a/Lyzer-BE/Database/MongoController.cs
+++ b/Lyzer-BE/Database/MongoController.cs
@@ -59,6 +59,11 @@ namespace Lyzer_BE.Database
             return _collection;
         }
 
+        public void SetCollection(string collectionName)
+        {
+            _collection = _database.GetCollection<T>(collectionName);
+        }
+
         public void InsertManyIntoCollection(List<T> documents)
         {
             try

--- a/Lyzer-BE/Program.cs
+++ b/Lyzer-BE/Program.cs
@@ -31,6 +31,7 @@ if (app.Environment.IsProduction())
 {
     IHydrationService hydrationService = new HydrationService();
     hydrationService.HydrateCurrentSchedule();
+    hydrationService.HydrateFollowingYearSchedule();
 }
 
 app.UseHttpsRedirection();

--- a/Lyzer-BE/Schedulers/Hydraters/CurrentScheduleHydrater.cs
+++ b/Lyzer-BE/Schedulers/Hydraters/CurrentScheduleHydrater.cs
@@ -13,6 +13,7 @@ namespace Lyzer_BE.Schedulers.Hydraters
             {
                 await Task.Delay(TimeSpan.FromDays(30), stoppingToken); // Delay between each run
                 hydrationService.HydrateCurrentSchedule();
+                hydrationService.HydrateFollowingYearSchedule();
             }
         }
     }


### PR DESCRIPTION
[feat(Hydration): Can now hydrate next season schedule data](https://github.com/Evanlab02/Lyzer/pull/68/commits/a5ae4ca4113b311444850af9d287b0b8a57ca691)
[fix(MongoDB): Converted logic for new database-collection structure](https://github.com/Evanlab02/Lyzer/pull/68/commits/00badb1612091392894fb0b438fd3782198ac320)
[fix(Schedule): Can now get schedule for current or next year. If failed default value gets returned](https://github.com/Evanlab02/Lyzer/pull/68/commits/d05e18d948ccddd819ee8e37ef1a477c6f41e3ea)