### PR TITLE
71 add flexible schedule year endpoint

### DIFF
--- a/Lyzer-BE.Tests/API/Controllers/TestScheduleController.cs
+++ b/Lyzer-BE.Tests/API/Controllers/TestScheduleController.cs
@@ -64,10 +64,10 @@ namespace Lyzer_BE.API.Tests
             var scheduleServiceMock = new Mock<IScheduleService>();
             var scheduleController = new ScheduleController(scheduleServiceMock.Object);
 
-            scheduleServiceMock.Setup(s => s.GetFullSchedule())
+            scheduleServiceMock.Setup(s => s.GetFullSchedule("current"))
                 .ReturnsAsync(Events);
 
-            List<RaceWeekendDTO>? result = scheduleController.GetSchedule().Result;
+            List<RaceWeekendDTO>? result = scheduleController.GetCurrent().Result;
             Assert.That(result, Is.EqualTo(Events));
         }
 
@@ -109,10 +109,10 @@ namespace Lyzer_BE.API.Tests
             var scheduleServiceMock = new Mock<IScheduleService>();
             var scheduleController = new ScheduleController(scheduleServiceMock.Object);
 
-            scheduleServiceMock.Setup(s => s.GetNextOrCurrentEvent())
+            scheduleServiceMock.Setup(s => s.GetNextOrCurrentRaceWeekend())
                 .ReturnsAsync(Event);
 
-            RaceWeekendDTO? result = scheduleController.GetNextEvent().Result;
+            RaceWeekendDTO? result = scheduleController.GetNextRaceWeekend().Result;
             Assert.That(result, Is.EqualTo(Event));
         }
     }

--- a/Lyzer-BE.Tests/API/Services/TestScheduleService.cs
+++ b/Lyzer-BE.Tests/API/Services/TestScheduleService.cs
@@ -1,8 +1,4 @@
-﻿using Lyzer_BE.API.DTOs;
-using Lyzer_BE.API.Services.Concrete;
-using Lyzer_BE.API.Services.Interfaces;
-
-namespace Lyzer_BE.Tests.API.Services
+﻿namespace Lyzer_BE.Tests.API.Services
 {
     [TestFixture]
     public class TestScheduleService

--- a/Lyzer-BE/API/Controllers/ScheduleController.cs
+++ b/Lyzer-BE/API/Controllers/ScheduleController.cs
@@ -15,17 +15,22 @@ namespace Lyzer_BE.API.Controllers
             _scheduleService = scheduleService;
         }
 
-        // GET api/schedule
         [HttpGet("current")]
-        public Task<List<RaceWeekendDTO>>? GetSchedule()
+        public Task<List<RaceWeekendDTO>>? GetCurrent()
         {
             return _scheduleService.GetFullSchedule();
         }
 
-        [HttpGet("/current/race/next")]
-        public Task<RaceWeekendDTO>? GetNextEvent()
+        [HttpGet("{year}")]
+        public Task<List<RaceWeekendDTO>>? GetScheduleForYear(string year)
         {
-            return _scheduleService.GetNextOrCurrentEvent();
+            return _scheduleService.GetFullSchedule(year);
+        }
+
+        [HttpGet("/current/raceweekend/next")]
+        public Task<RaceWeekendDTO>? GetNextRaceWeekend()
+        {
+            return _scheduleService.GetNextOrCurrentRaceWeekend();
         }
 
     }

--- a/Lyzer-BE/API/Services/Concrete/HydrationService.cs
+++ b/Lyzer-BE/API/Services/Concrete/HydrationService.cs
@@ -15,28 +15,34 @@ namespace Lyzer_BE.API.Services.Concrete
             var request = new RestRequest($"current.json");
             var response = await client.GetAsync<ScheduleDTO>(request);
 
-            MongoController<RaceWeekendDTO> mongoController = new("Schedules", "2023");
+            MongoController<RaceWeekendDTO> mongoController = new("Schedules", DateTime.Now.Year.ToString());
             var filterValues = Builders<RaceWeekendDTO>.Filter.Empty;
             mongoController.DeleteManyFromCollection(filterValues);
 
             mongoController.InsertManyIntoCollection(response.ScheduleData.ScheduleTable.RaceWeekends);
+
             return response;
         }
 
         public async Task<ScheduleDTO> HydrateFollowingYearSchedule()
         {
+            var nextYear = DateTime.Now.AddYears(1).Year.ToString();
+
             var options = new RestClientOptions("http://ergast.com/api/f1/");
             var client = new RestClient(options);
-            var request = new RestRequest($"2024.json");
+            var request = new RestRequest($"{nextYear}.json");
             var response = await client.GetAsync<ScheduleDTO>(request);
 
-            MongoController<RaceWeekendDTO> mongoController = new("Schedules", "2024");
-            var filterValues = Builders<RaceWeekendDTO>.Filter.Empty;
-            mongoController.DeleteManyFromCollection(filterValues);
-
-            if (response.ScheduleData.ScheduleTable.RaceWeekends.Count != 0)
+            if (response.ScheduleData.ScheduleTable.RaceWeekends.Count > 0)
             {
-                mongoController.InsertManyIntoCollection(response.ScheduleData.ScheduleTable.RaceWeekends);
+                MongoController<RaceWeekendDTO> mongoController = new("Schedules", nextYear);
+                var filterValues = Builders<RaceWeekendDTO>.Filter.Empty;
+                mongoController.DeleteManyFromCollection(filterValues);
+
+                if (response.ScheduleData.ScheduleTable.RaceWeekends.Count != 0)
+                {
+                    mongoController.InsertManyIntoCollection(response.ScheduleData.ScheduleTable.RaceWeekends);
+                }
             }
 
             return response;

--- a/Lyzer-BE/API/Services/Concrete/HydrationService.cs
+++ b/Lyzer-BE/API/Services/Concrete/HydrationService.cs
@@ -47,5 +47,28 @@ namespace Lyzer_BE.API.Services.Concrete
 
             return response;
         }
+
+        public async Task<ScheduleDTO> HydrateSchedule(string year)
+        {
+            var options = new RestClientOptions("http://ergast.com/api/f1/");
+            var client = new RestClient(options);
+            var request = new RestRequest($"{year}.json");
+            var response = await client.GetAsync<ScheduleDTO>(request);
+
+            //TODO: Move duplicated code into method that can be used by other hydration methods.
+            if (response.ScheduleData.ScheduleTable.RaceWeekends.Count > 0)
+            {
+                MongoController<RaceWeekendDTO> mongoController = new("Schedules", year);
+                var filterValues = Builders<RaceWeekendDTO>.Filter.Empty;
+                mongoController.DeleteManyFromCollection(filterValues);
+
+                if (response.ScheduleData.ScheduleTable.RaceWeekends.Count != 0)
+                {
+                    mongoController.InsertManyIntoCollection(response.ScheduleData.ScheduleTable.RaceWeekends);
+                }
+            }
+
+            return response;
+        }
     }
 }

--- a/Lyzer-BE/API/Services/Concrete/ScheduleService.cs
+++ b/Lyzer-BE/API/Services/Concrete/ScheduleService.cs
@@ -8,64 +8,107 @@ namespace Lyzer_BE.API.Services.Concrete
     public class ScheduleService : IScheduleService
     {
         private readonly MongoController<RaceWeekendDTO> _mongoController;
+        private readonly IHydrationService _hydrationService;
 
-        public ScheduleService(bool testing = false)
+        public ScheduleService(IHydrationService hydrationService)
         {
-            if (!testing)
+            _mongoController = new MongoController<RaceWeekendDTO>("Schedules", DateTime.Now.Year.ToString());
+            _hydrationService = hydrationService;
+        }
+
+        public async Task<List<RaceWeekendDTO>>? GetFullSchedule(string year)
+        {
+            if (
+                !year.Equals("current") &&
+                !String.IsNullOrEmpty(year) &&
+                Int32.Parse(year) >= 1950 &&
+                Int32.Parse(year) <= DateTime.Now.AddYears(1).Year
+            )
             {
-                var today = DateTime.Now;
-                var currentYear = today.Year;
-                _mongoController = new MongoController<RaceWeekendDTO>("Schedules", currentYear.ToString());
+                var collectionExists = await _mongoController.SetCollection(year);
+
+                var tempSchedule = new ScheduleDTO();
+
+                if (!collectionExists)
+                {
+                    await _mongoController.CreateCollection(year);
+                    tempSchedule = await _hydrationService.HydrateSchedule(year);
+                }
+
+                List<RaceWeekendDTO> schedule = new();
+
+                if (!collectionExists)
+                {
+                    schedule = tempSchedule.ScheduleData.ScheduleTable.RaceWeekends;
+                }
+                else
+                {
+                    schedule = await _mongoController.FindManyFromCollection(Builders<RaceWeekendDTO>.Filter.Empty);
+                }
+                    
+
+                if (schedule.Count == 0)
+                {
+                    var result = await _hydrationService.HydrateSchedule(year);
+                    schedule = result.ScheduleData.ScheduleTable.RaceWeekends;
+                }
+
+                await _mongoController.SetCollection(DateTime.Now.Year.ToString());
+
+                return schedule;
             }
+            else if (year.Equals("current"))
+            {
+                return await _mongoController.FindManyFromCollection(Builders<RaceWeekendDTO>.Filter.Empty);
+            }
+
+            //Throw some exception once exception handler is created.
+
+            return new List<RaceWeekendDTO>();
         }
 
-        public async Task<List<RaceWeekendDTO>>? GetFullSchedule()
-        {
-            return await _mongoController.FindManyFromCollection(Builders<RaceWeekendDTO>.Filter.Empty);
-        }
-
-        public async Task<RaceWeekendDTO>? GetNextOrCurrentEvent()
+        public async Task<RaceWeekendDTO>? GetNextOrCurrentRaceWeekend()
         {
             var today = DateTime.Now;
             var twoYearsFromNow = today.AddYears(2);
 
-            RaceWeekendDTO nextEvent = new()
+            RaceWeekendDTO nextRaceWeekend = new()
             {
                 Date = $"{twoYearsFromNow.Year}-01-01",
                 Time = "00:00:00",
             };
 
-            var events = await _mongoController.FindManyFromCollection(Builders<RaceWeekendDTO>.Filter.Empty);
+            var raceWeekends = await _mongoController.FindManyFromCollection(Builders<RaceWeekendDTO>.Filter.Empty);
 
-            foreach (RaceWeekendDTO eventDTO in events)
+            foreach (RaceWeekendDTO raceWeekendDTO in raceWeekends)
             {
-                var nextEventDatetime = DateTime.Parse($"{nextEvent.Date} {nextEvent.Time}").AddHours(2.5);
-                var endDateTime = DateTime.Parse($"{eventDTO.Date} {eventDTO.Time}").AddHours(2.5);
+                var nextRWDatetime = DateTime.Parse($"{nextRaceWeekend.Date} {nextRaceWeekend.Time}").AddHours(2.5);
+                var endDateTime = DateTime.Parse($"{raceWeekendDTO.Date} {raceWeekendDTO.Time}").AddHours(2.5);
 
-                if (endDateTime > today && nextEventDatetime > endDateTime)
+                if (endDateTime > today && nextRWDatetime > endDateTime)
                 {
-                    nextEvent = eventDTO;
+                    nextRaceWeekend = raceWeekendDTO;
                 }
             };
 
-            if (nextEvent.Date == $"{twoYearsFromNow.Year}-01-01")
+            if (nextRaceWeekend.Date == $"{twoYearsFromNow.Year}-01-01")
             {
-                _mongoController.SetCollection((today.Year + 1).ToString());
-                var nextYearEvents = await _mongoController.FindManyFromCollection(Builders<RaceWeekendDTO>.Filter.Empty);
+                await _mongoController.SetCollection((today.Year + 1).ToString());
+                var nextYearRaceWeekends = await _mongoController.FindManyFromCollection(Builders<RaceWeekendDTO>.Filter.Empty);
 
-                foreach (RaceWeekendDTO eventDTO in nextYearEvents)
+                foreach (RaceWeekendDTO raceWeekendDTO in nextYearRaceWeekends)
                 {
-                    var nextEventDatetime = DateTime.Parse($"{nextEvent.Date} {nextEvent.Time}").AddHours(2.5);
-                    var endDateTime = DateTime.Parse($"{eventDTO.Date} {eventDTO.Time}").AddHours(2.5);
+                    var nextRWDatetime = DateTime.Parse($"{nextRaceWeekend.Date} {nextRaceWeekend.Time}").AddHours(2.5);
+                    var endDateTime = DateTime.Parse($"{raceWeekendDTO.Date} {raceWeekendDTO.Time}").AddHours(2.5);
 
-                    if (endDateTime > today && nextEventDatetime > endDateTime)
+                    if (endDateTime > today && nextRWDatetime > endDateTime)
                     {
-                        nextEvent = eventDTO;
+                        nextRaceWeekend = raceWeekendDTO;
                     }
                 };
             }
 
-            return nextEvent;
+            return nextRaceWeekend;
         }
     }
 }

--- a/Lyzer-BE/API/Services/Concrete/ScheduleService.cs
+++ b/Lyzer-BE/API/Services/Concrete/ScheduleService.cs
@@ -45,7 +45,7 @@ namespace Lyzer_BE.API.Services.Concrete
                 {
                     schedule = await _mongoController.FindManyFromCollection(Builders<RaceWeekendDTO>.Filter.Empty);
                 }
-                    
+
 
                 if (schedule.Count == 0)
                 {

--- a/Lyzer-BE/API/Services/Interfaces/IHydrationService.cs
+++ b/Lyzer-BE/API/Services/Interfaces/IHydrationService.cs
@@ -5,7 +5,7 @@ namespace Lyzer_BE.API.Services.Interfaces
     public interface IHydrationService
     {
         public Task<ScheduleDTO> HydrateCurrentSchedule();
-
         public Task<ScheduleDTO> HydrateFollowingYearSchedule();
+        public Task<ScheduleDTO> HydrateSchedule(string year);
     }
 }

--- a/Lyzer-BE/API/Services/Interfaces/IScheduleService.cs
+++ b/Lyzer-BE/API/Services/Interfaces/IScheduleService.cs
@@ -4,8 +4,8 @@ namespace Lyzer_BE.API.Services.Interfaces
 {
     public interface IScheduleService
     {
-        public Task<List<RaceWeekendDTO>>? GetFullSchedule();
+        public Task<List<RaceWeekendDTO>>? GetFullSchedule(string year = "current");
 
-        public Task<RaceWeekendDTO>? GetNextOrCurrentEvent();
+        public Task<RaceWeekendDTO>? GetNextOrCurrentRaceWeekend();
     }
 }

--- a/Lyzer-BE/Database/MongoController.cs
+++ b/Lyzer-BE/Database/MongoController.cs
@@ -59,9 +59,49 @@ namespace Lyzer_BE.Database
             return _collection;
         }
 
-        public void SetCollection(string collectionName)
+        public bool SetCollection(string collectionName)
         {
-            _collection = _database.GetCollection<T>(collectionName);
+            bool collectionExists = DoesCollectionExist(collectionName);
+
+            if (collectionExists)
+                _collection = _database.GetCollection<T>(collectionName);
+
+            return collectionExists;
+        }
+
+        public bool CreateCollection(string collectionName)
+        {
+            bool collectionExists = DoesCollectionExist(collectionName);
+
+            if (!collectionExists)
+            {
+                _database.CreateCollection(collectionName);
+            }
+
+            return collectionExists;
+        }
+        public bool DeleteCollection(string collectionName)
+        {
+            bool collectionExists = DoesCollectionExist(collectionName);
+
+            if (collectionExists)
+            {
+                _database.DropCollection(collectionName);
+            }
+
+            return collectionExists;
+        }
+
+        public bool DoesCollectionExist(string collectionName)
+        {
+            var collections = _database.ListCollectionNames().ToList();
+
+            if (!collections.Any(x => x.Equals(collectionName)))
+            {
+                return false;
+            }
+
+            return true;
         }
 
         public void InsertManyIntoCollection(List<T> documents)

--- a/Lyzer-BE/Database/MongoController.cs
+++ b/Lyzer-BE/Database/MongoController.cs
@@ -59,9 +59,9 @@ namespace Lyzer_BE.Database
             return _collection;
         }
 
-        public bool SetCollection(string collectionName)
+        public async Task<bool> SetCollection(string collectionName)
         {
-            bool collectionExists = DoesCollectionExist(collectionName);
+            bool collectionExists = await DoesCollectionExist(collectionName);
 
             if (collectionExists)
                 _collection = _database.GetCollection<T>(collectionName);
@@ -69,32 +69,32 @@ namespace Lyzer_BE.Database
             return collectionExists;
         }
 
-        public bool CreateCollection(string collectionName)
+        public async Task<bool> CreateCollection(string collectionName)
         {
-            bool collectionExists = DoesCollectionExist(collectionName);
+            bool collectionExists = await DoesCollectionExist(collectionName);
 
             if (!collectionExists)
             {
-                _database.CreateCollection(collectionName);
+                await _database.CreateCollectionAsync(collectionName);
             }
 
             return collectionExists;
         }
-        public bool DeleteCollection(string collectionName)
+        public async Task<bool> DeleteCollection(string collectionName)
         {
-            bool collectionExists = DoesCollectionExist(collectionName);
+            bool collectionExists = await DoesCollectionExist(collectionName);
 
             if (collectionExists)
             {
-                _database.DropCollection(collectionName);
+                await _database.DropCollectionAsync(collectionName);
             }
 
             return collectionExists;
         }
 
-        public bool DoesCollectionExist(string collectionName)
+        public async Task<bool> DoesCollectionExist(string collectionName)
         {
-            var collections = _database.ListCollectionNames().ToList();
+            var collections = _database.ListCollectionNamesAsync().Result.ToList();
 
             if (!collections.Any(x => x.Equals(collectionName)))
             {


### PR DESCRIPTION
[chore(Hydration): using DateTime.Now for Schedule Hydration](https://github.com/Evanlab02/Lyzer/commit/5461dcc5d3e568d2ea4110c90605db6e9e027b55)
[feat(Mongo): Updating SetCollection and new collection methods](https://github.com/Evanlab02/Lyzer/commit/1215c0ce18556d074d1e0d3f7a150d6f35c68634)
[feat(Schedule): Flexible schedule endpoint created](https://github.com/Evanlab02/Lyzer/commit/ec9b87f517e6f38bb92fa51ced5bbc2f2ab76723)
[chore(Cleanup): cleanup.](https://github.com/Evanlab02/Lyzer/commit/54573a549c7b367a93fc8c6de0129611f97cca1a)